### PR TITLE
Add badges to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,8 @@
 # SVG to JSX Figma Plugin
 
+[![](https://img.shields.io/endpoint?url=https://figma-plugin-badges.vercel.app/api/installs/749818562498396194)](https://www.figma.com/community/plugin/749818562498396194/SVG-to-JSX)
+[![](https://img.shields.io/endpoint?url=https://figma-plugin-badges.vercel.app/api/likes/749818562498396194)](https://www.figma.com/community/plugin/749818562498396194/SVG-to-JSX)
+
 ![Plugin UI](./ui.png)
 
 This plugins does what it says really, gets your SVG code in figma and gives you ready to use JSX you can copy and paste into your react apps and its written in ...🥁🥁 VUE 🥁🥁...


### PR DESCRIPTION
This plugin is awesome and I thought it could use a few badges to show that off. This is what the readme looks like with badges that show the install and like count:

<img width="1037" alt="Screen Shot 2020-08-31 at 01 31 36" src="https://user-images.githubusercontent.com/531488/91699925-e0726000-eb29-11ea-9136-cc65113f4463.png">

The plugin that powers these badges is open source here: https://github.com/kevinwuhoo/figma-plugin-badges.